### PR TITLE
Add theme-driven window resize zones

### DIFF
--- a/XCBKit/GNUmakefile
+++ b/XCBKit/GNUmakefile
@@ -72,6 +72,7 @@ $(FRAMEWORK_NAME)_HEADER_FILES = \
 			enums/EXErrorMessages.h \
 			enums/EIcccm.h \
 			enums/EMousePosition.h \
+			enums/EResizeDirection.h \
 			enums/EEwmh.h \
 			enums/ERequests.h \
 			protocols/server/Server.h \

--- a/XCBKit/XCBCursor.h
+++ b/XCBKit/XCBCursor.h
@@ -28,11 +28,17 @@
 @property (strong, nonatomic) NSString *resizeLeftCursorName;
 @property (strong, nonatomic) NSString *resizeTopCursorName;
 @property (strong, nonatomic) NSString *resizeBottomRightCornerCursorName;
+@property (strong, nonatomic) NSString *resizeTopLeftCornerCursorName;
+@property (strong, nonatomic) NSString *resizeTopRightCornerCursorName;
+@property (strong, nonatomic) NSString *resizeBottomLeftCornerCursorName;
 @property (assign, nonatomic) BOOL leftPointerSelected;
 @property (assign, nonatomic) BOOL resizeBottomSelected;
 @property (assign, nonatomic) BOOL resizeRightSelected;
 @property (assign, nonatomic) BOOL resizeLeftSelected;
 @property (assign, nonatomic) BOOL resizeBottomRightCornerSelected;
+@property (assign, nonatomic) BOOL resizeTopLeftCornerSelected;
+@property (assign, nonatomic) BOOL resizeTopRightCornerSelected;
+@property (assign, nonatomic) BOOL resizeBottomLeftCornerSelected;
 @property (assign, nonatomic) BOOL resizeTopSelected;
 
 - (instancetype)initWithConnection:(XCBConnection *)aConnection screen:(XCBScreen*)aScreen;

--- a/XCBKit/XCBCursor.m
+++ b/XCBKit/XCBCursor.m
@@ -25,6 +25,12 @@
 @synthesize resizeLeftSelected;
 @synthesize resizeBottomRightCornerCursorName;
 @synthesize resizeBottomRightCornerSelected;
+@synthesize resizeTopLeftCornerCursorName;
+@synthesize resizeTopLeftCornerSelected;
+@synthesize resizeTopRightCornerCursorName;
+@synthesize resizeTopRightCornerSelected;
+@synthesize resizeBottomLeftCornerCursorName;
+@synthesize resizeBottomLeftCornerSelected;
 @synthesize resizeTopCursorName;
 @synthesize resizeTopSelected;
 
@@ -51,12 +57,16 @@
 
     cursors = [[NSMutableDictionary alloc] init];
 
+    // Use standard X11 cursor font names (same as XCreateFontCursor)
     leftPointerName = @"left_ptr";
-    resizeBottomCursorName = @"s-resize";
-    resizeRightCursorName = @"w-resize";
-    resizeLeftCursorName = @"e-resize";
-    resizeBottomRightCornerCursorName = @"nwse-resize";
-    resizeTopCursorName = @"n-resize";
+    resizeBottomCursorName = @"bottom_side";
+    resizeRightCursorName = @"right_side";
+    resizeLeftCursorName = @"left_side";
+    resizeBottomRightCornerCursorName = @"bottom_right_corner";
+    resizeTopLeftCornerCursorName = @"top_left_corner";
+    resizeTopRightCornerCursorName = @"top_right_corner";
+    resizeBottomLeftCornerCursorName = @"bottom_left_corner";
+    resizeTopCursorName = @"top_side";
 
 
     cursor = xcb_cursor_load_cursor(context, [leftPointerName cString]);
@@ -67,10 +77,14 @@
     [cursors setObject:[NSNumber numberWithUnsignedInt:cursor] forKey:resizeRightCursorName];
     cursor = xcb_cursor_load_cursor(context, [resizeLeftCursorName cString]);
     [cursors setObject:[NSNumber numberWithUnsignedInt:cursor] forKey:resizeLeftCursorName];
-    cursor = xcb_cursor_load_cursor(context, [resizeLeftCursorName cString]);
-    [cursors setObject:[NSNumber numberWithUnsignedInt:cursor] forKey:resizeLeftCursorName];
     cursor = xcb_cursor_load_cursor(context, [resizeBottomRightCornerCursorName cString]);
     [cursors setObject:[NSNumber numberWithUnsignedInt:cursor] forKey:resizeBottomRightCornerCursorName];
+    cursor = xcb_cursor_load_cursor(context, [resizeTopLeftCornerCursorName cString]);
+    [cursors setObject:[NSNumber numberWithUnsignedInt:cursor] forKey:resizeTopLeftCornerCursorName];
+    cursor = xcb_cursor_load_cursor(context, [resizeTopRightCornerCursorName cString]);
+    [cursors setObject:[NSNumber numberWithUnsignedInt:cursor] forKey:resizeTopRightCornerCursorName];
+    cursor = xcb_cursor_load_cursor(context, [resizeBottomLeftCornerCursorName cString]);
+    [cursors setObject:[NSNumber numberWithUnsignedInt:cursor] forKey:resizeBottomLeftCornerCursorName];
     cursor = xcb_cursor_load_cursor(context, [resizeTopCursorName cString]);
     [cursors setObject:[NSNumber numberWithUnsignedInt:cursor] forKey:resizeTopCursorName];
 
@@ -136,8 +150,47 @@
             resizeRightSelected = NO;
             resizeLeftSelected = NO;
             resizeBottomRightCornerSelected = NO;
+            resizeTopLeftCornerSelected = NO;
+            resizeTopRightCornerSelected = NO;
+            resizeBottomLeftCornerSelected = NO;
             resizeTopSelected = YES;
-           break;
+            break;
+        case TopLeftCorner:
+            cursor = [[cursors objectForKey:resizeTopLeftCornerCursorName] unsignedIntValue];
+            leftPointerSelected = NO;
+            resizeBottomSelected = NO;
+            resizeRightSelected = NO;
+            resizeLeftSelected = NO;
+            resizeBottomRightCornerSelected = NO;
+            resizeTopLeftCornerSelected = YES;
+            resizeTopRightCornerSelected = NO;
+            resizeBottomLeftCornerSelected = NO;
+            resizeTopSelected = NO;
+            break;
+        case TopRightCorner:
+            cursor = [[cursors objectForKey:resizeTopRightCornerCursorName] unsignedIntValue];
+            leftPointerSelected = NO;
+            resizeBottomSelected = NO;
+            resizeRightSelected = NO;
+            resizeLeftSelected = NO;
+            resizeBottomRightCornerSelected = NO;
+            resizeTopLeftCornerSelected = NO;
+            resizeTopRightCornerSelected = YES;
+            resizeBottomLeftCornerSelected = NO;
+            resizeTopSelected = NO;
+            break;
+        case BottomLeftCorner:
+            cursor = [[cursors objectForKey:resizeBottomLeftCornerCursorName] unsignedIntValue];
+            leftPointerSelected = NO;
+            resizeBottomSelected = NO;
+            resizeRightSelected = NO;
+            resizeLeftSelected = NO;
+            resizeBottomRightCornerSelected = NO;
+            resizeTopLeftCornerSelected = NO;
+            resizeTopRightCornerSelected = NO;
+            resizeBottomLeftCornerSelected = YES;
+            resizeTopSelected = NO;
+            break;
 
         default:
             break;
@@ -175,6 +228,9 @@
 
     resizeTopCursorName = nil;
     resizeBottomRightCornerCursorName = nil;
+    resizeTopLeftCornerCursorName = nil;
+    resizeTopRightCornerCursorName = nil;
+    resizeBottomLeftCornerCursorName = nil;
     resizeLeftCursorName = nil;
     resizeRightCursorName = nil;
     resizeBottomCursorName = nil;

--- a/XCBKit/XCBFrame.h
+++ b/XCBKit/XCBFrame.h
@@ -10,6 +10,7 @@
 #import "XCBWindow.h"
 #import "XCBConnection.h"
 #import "enums/EMousePosition.h"
+#import "enums/EResizeDirection.h"
 
 
 #define WM_MIN_WINDOW_HEIGHT 431
@@ -19,7 +20,16 @@ typedef NS_ENUM(NSInteger, childrenMask)
 {
     TitleBar = 0,
     ClientWindow = 1,
-    ResizeHandle = 2
+    ResizeHandle = 2,    // Legacy (keep for backwards compatibility)
+    ResizeZoneNW = 10,
+    ResizeZoneN = 11,
+    ResizeZoneNE = 12,
+    ResizeZoneE = 13,
+    ResizeZoneSE = 14,
+    ResizeZoneS = 15,
+    ResizeZoneSW = 16,
+    ResizeZoneW = 17,
+    ResizeZoneGrowBox = 18  // Theme-defined grow box overlay
 };
 
 @interface XCBFrame : XCBWindow
@@ -53,6 +63,12 @@ typedef NS_ENUM(NSInteger, childrenMask)
 - (void) restoreDimensionAndPosition;
 - (void) createResizeHandle;
 - (void) updateResizeHandlePosition;
+- (void) raiseResizeHandle;
+
+// Theme-driven resize zones
+- (void) createResizeZonesFromTheme;
+- (void) updateAllResizeZonePositions;
+- (void) destroyResizeZones;
 
 
  /********************************

--- a/XCBKit/enums/EMousePosition.h
+++ b/XCBKit/enums/EMousePosition.h
@@ -9,11 +9,14 @@
 
 typedef NS_ENUM(NSInteger, MousePosition)
 {
+    None = 0,
     RightBorder,
     LeftBorder,
     TopBorder,
     BottomBorder,
     BottomRightCorner,
-    Error,
-    None
+    TopLeftCorner,
+    TopRightCorner,
+    BottomLeftCorner,
+    Error
 };

--- a/XCBKit/enums/EResizeDirection.h
+++ b/XCBKit/enums/EResizeDirection.h
@@ -1,0 +1,22 @@
+//
+// EResizeDirection.h
+// XCBKit
+//
+// Resize direction enumeration for theme-driven resize zones.
+// These values are used by themes implementing the resize zone protocol
+// and by the window manager to create invisible capture windows.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, EResizeDirection) {
+    EResizeDirectionNone = 0,
+    EResizeDirectionNorth,        // Top edge
+    EResizeDirectionSouth,        // Bottom edge
+    EResizeDirectionEast,         // Right edge
+    EResizeDirectionWest,         // Left edge
+    EResizeDirectionNorthWest,    // Top-left corner
+    EResizeDirectionNorthEast,    // Top-right corner
+    EResizeDirectionSouthEast,    // Bottom-right corner
+    EResizeDirectionSouthWest     // Bottom-left corner
+};


### PR DESCRIPTION
## Summary
- Query GSTheme for resize zone configuration
- Create invisible input-only windows at edges/corners for resize capture
- Handle cursor changes via EnterNotify/LeaveNotify
- Use X11 standard cursor names

## Companion PR
- Theme: https://github.com/gershwin-desktop/gershwin-eau-theme/pull/20

**Note:** Both PRs must be merged together for the feature to work.