### PR TITLE
Add theme-driven rounded window corners via XCB shape mask

### DIFF
--- a/XCBKit/XCBFrame.h
+++ b/XCBKit/XCBFrame.h
@@ -64,6 +64,7 @@ typedef NS_ENUM(NSInteger, childrenMask)
 - (void) createResizeHandle;
 - (void) updateResizeHandlePosition;
 - (void) raiseResizeHandle;
+- (void) applyRoundedCornersShapeMask;
 
 // Theme-driven resize zones
 - (void) createResizeZonesFromTheme;

--- a/XCBKit/XCBShape.h
+++ b/XCBKit/XCBShape.h
@@ -36,6 +36,8 @@
 - (BOOL) checkSupported;
 - (void) createPixmapsAndGCs;
 - (void) createArcsWithRadius:(int)aRadius;
+- (void) createTopArcsWithRadius:(int)aRadius;
+- (void) createRoundedCornersWithTopRadius:(int)topRadius bottomRadius:(int)bottomRadius;
 - (void) calculateDimensionsFromGeometries:(XCBGeometryReply*)aGeometryReply;
 
 @end

--- a/XCBKit/XCBShape.m
+++ b/XCBKit/XCBShape.m
@@ -134,6 +134,94 @@
 
 }
 
+- (void) createTopArcsWithRadius:(int)aRadius
+{
+    xcb_connection_t *conn = [connection connection];
+    radius = aRadius;
+    int diameter = radius * 2;
+
+    // Only top corners get arcs, bottom stays rectangular
+    xcb_arc_t bArcs[] = {
+        { -1, -1, diameter, diameter, 0, 360 << 6 },                // top-left
+        { orWidth - diameter, -1, diameter, diameter, 0, 360 << 6 }, // top-right
+    };
+
+    xcb_rectangle_t brects[] = {
+        { radius, 0, orWidth - diameter, orHeight },  // center vertical strip
+        { 0, radius, orWidth, orHeight - radius },    // below top corners
+    };
+
+    // Clear to black (transparent), then fill valid regions white (opaque)
+    xcb_rectangle_t bounding = {0, 0, orWidth, orHeight};
+    xcb_poly_fill_rectangle(conn, borderPixmap, black, 1, &bounding);
+    xcb_poly_fill_rectangle(conn, borderPixmap, white, 2, brects);
+    xcb_poly_fill_arc(conn, borderPixmap, white, 2, bArcs);
+
+    // Apply shape mask
+    xcb_shape_mask(conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_BOUNDING, winId, -borderWidth, -borderWidth, borderPixmap);
+}
+
+- (void) createRoundedCornersWithTopRadius:(int)topRadius bottomRadius:(int)bottomRadius
+{
+    xcb_connection_t *conn = [connection connection];
+
+    // Clear pixmap to black (transparent)
+    xcb_rectangle_t bounding = {0, 0, orWidth, orHeight};
+    xcb_poly_fill_rectangle(conn, borderPixmap, black, 1, &bounding);
+
+    // Build rectangles for the straight edges
+    int topDiameter = topRadius * 2;
+    int bottomDiameter = bottomRadius * 2;
+
+    // Center strip (between left and right corners)
+    int leftEdge = (topRadius > bottomRadius) ? topRadius : bottomRadius;
+    int rightEdge = (topRadius > bottomRadius) ? topRadius : bottomRadius;
+    xcb_rectangle_t centerStrip = { leftEdge, 0, orWidth - leftEdge - rightEdge, orHeight };
+    xcb_poly_fill_rectangle(conn, borderPixmap, white, 1, &centerStrip);
+
+    // Left strip (between top-left and bottom-left corners)
+    if (topRadius > 0 || bottomRadius > 0) {
+        int leftStripTop = topRadius;
+        int leftStripBottom = bottomRadius;
+        int leftStripHeight = orHeight - leftStripTop - leftStripBottom;
+        if (leftStripHeight > 0) {
+            xcb_rectangle_t leftStrip = { 0, leftStripTop, leftEdge, leftStripHeight };
+            xcb_poly_fill_rectangle(conn, borderPixmap, white, 1, &leftStrip);
+        }
+    }
+
+    // Right strip (between top-right and bottom-right corners)
+    if (topRadius > 0 || bottomRadius > 0) {
+        int rightStripTop = topRadius;
+        int rightStripBottom = bottomRadius;
+        int rightStripHeight = orHeight - rightStripTop - rightStripBottom;
+        if (rightStripHeight > 0) {
+            xcb_rectangle_t rightStrip = { orWidth - rightEdge, rightStripTop, rightEdge, rightStripHeight };
+            xcb_poly_fill_rectangle(conn, borderPixmap, white, 1, &rightStrip);
+        }
+    }
+
+    // Draw corner arcs
+    if (topRadius > 0) {
+        xcb_arc_t topArcs[] = {
+            { -1, -1, topDiameter, topDiameter, 0, 360 << 6 },                    // top-left
+            { orWidth - topDiameter, -1, topDiameter, topDiameter, 0, 360 << 6 }, // top-right
+        };
+        xcb_poly_fill_arc(conn, borderPixmap, white, 2, topArcs);
+    }
+
+    if (bottomRadius > 0) {
+        xcb_arc_t bottomArcs[] = {
+            { -1, orHeight - bottomDiameter, bottomDiameter, bottomDiameter, 0, 360 << 6 },                    // bottom-left
+            { orWidth - bottomDiameter, orHeight - bottomDiameter, bottomDiameter, bottomDiameter, 0, 360 << 6 }, // bottom-right
+        };
+        xcb_poly_fill_arc(conn, borderPixmap, white, 2, bottomArcs);
+    }
+
+    // Apply shape mask
+    xcb_shape_mask(conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_BOUNDING, winId, -borderWidth, -borderWidth, borderPixmap);
+}
+
 - (void) dealloc
 {
     if (shapeExtensionReply)


### PR DESCRIPTION
## Summary

- Adds support for rounded window corners using XCB shape extension
- Queries theme for corner radii via informal protocol (`titlebarCornerRadius`, `windowBottomCornerRadius`)
- Defaults to 0 (square corners) if theme doesn't provide values - fully backward compatible
- Supports independent top and bottom corner radii

## Configuration

Themes can implement these optional methods:

```objc
- (CGFloat)titlebarCornerRadius;      // Top corners (0 = square)
- (CGFloat)windowBottomCornerRadius;  // Bottom corners (0 = square)
```

## Related

Requires gershwin-eau-theme PR for visual effect (theme provides the radius values).