### PR TITLE
Fix window content clipping during resize and maximize

### DIFF
--- a/WindowManager/URSHybridEventHandler.m
+++ b/WindowManager/URSHybridEventHandler.m
@@ -432,8 +432,10 @@
         [self.compositingManager performRepairNow];
     }
 
-    // Check if there are more events available
-    if (xcb_poll_for_event([connection connection])) {
+    // If we hit the event limit, assume more events may be available
+    // Don't poll again here as both xcb_poll_for_event and xcb_poll_for_queued_event
+    // remove events from the queue, which would cause lost events
+    if (eventsProcessed >= maxEventsPerCall) {
         moreEventsAvailable = YES;
     }
 

--- a/XCBKit/XCBConnection.m
+++ b/XCBKit/XCBConnection.m
@@ -1443,6 +1443,8 @@ static XCBConnection *sharedInstance;
         {
             XCBRect startRect = [frame windowRect];
             [frame restoreDimensionAndPosition];
+            xcb_flush([self connection]);
+            [frame applyRoundedCornersShapeMask];
 
             {
                 Class compositorClass = NSClassFromString(@"URSCompositingManager");
@@ -1523,6 +1525,12 @@ static XCBConnection *sharedInstance;
         
         /*** Update resize zone positions if they exist ***/
         [frame updateAllResizeZonePositions];
+
+        /*** Flush to ensure X server has processed configure requests ***/
+        xcb_flush([self connection]);
+
+        /*** Update shape mask for new dimensions ***/
+        [frame applyRoundedCornersShapeMask];
 
         ewmhService = nil;
         rootWindow = nil;


### PR DESCRIPTION
## Summary

- Fix window content being clipped when resizing windows larger than their original size
- Partial fix for window content clipping when maximizing (still has issues)
- Improve resize performance with inline ConfigureNotify events

## Details

The XCB shape mask for rounded corners was only applied once during window decoration. When windows were resized larger or maximized, the shape mask still clipped content to the original dimensions.

This PR updates the shape mask after:
- Resize operations (in `XCBFrame.m`)
- Maximize and restore operations (in `XCBConnection.m`)

Also includes:
- Inline synthetic ConfigureNotify during resize for better performance (avoids X server round-trip)
- Fix for potential event dropping in the event handler loop

**Note:** Maximize still has some clipping issues that need further investigation.