### PR TITLE
Fix menu requiring two clicks after window focus change

### DIFF
--- a/XCBKit/XCBConnection.h
+++ b/XCBKit/XCBConnection.h
@@ -55,6 +55,10 @@
 @property (nonatomic, assign) uint32_t cachedWorkareaWidth;
 @property (nonatomic, assign) uint32_t cachedWorkareaHeight;
 
+// Expected focus tracking to prevent race conditions
+@property (nonatomic, assign) xcb_window_t expectedFocusWindow;
+@property (nonatomic, assign) xcb_timestamp_t expectedFocusTimestamp;
+
 + (XCBConnection *) sharedConnectionAsWindowManager:(BOOL)asWindowManager;
 - (xcb_connection_t *) connection;
 /**


### PR DESCRIPTION
## Summary

- Fix race condition where stale FocusIn events could overwrite `_NET_ACTIVE_WINDOW` after clicking on a window
- Track expected focus window and timestamp to skip redundant focus updates
- Skip focus handling for popup menus to prevent menu clicks from stealing focus