### PR TITLE
Add window tiling and snap-to-edge support [WIP]

### DIFF
--- a/WindowManager/GNUmakefile
+++ b/WindowManager/GNUmakefile
@@ -20,6 +20,7 @@ $(APP_NAME)_OBJC_FILES = \
 		URSHybridEventHandler.m \
 		URSWindowSwitcher.m \
 		URSWindowSwitcherOverlay.m \
+		URSSnapPreviewOverlay.m \
 		URSCompositingManager.m \
 		URSRenderingContext.m \
 		UROSWMApplication.m \
@@ -30,6 +31,7 @@ $(APP_NAME)_HEADER_FILES = \
 		URSHybridEventHandler.h \
 		URSWindowSwitcher.h \
 		URSWindowSwitcherOverlay.h \
+		URSSnapPreviewOverlay.h \
 		URSCompositingManager.h \
 		URSRenderingContext.h \
 		UROSWMApplication.h \

--- a/WindowManager/URSSnapPreviewOverlay.h
+++ b/WindowManager/URSSnapPreviewOverlay.h
@@ -1,0 +1,21 @@
+//
+//  URSSnapPreviewOverlay.h
+//  uroswm - Window Snap Preview Overlay
+//
+//  Shows a semi-transparent preview of where a window will snap
+//  when dragged to screen edges (top = maximize, left/right = half)
+//
+
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+@interface URSSnapPreviewOverlay : NSWindow
+
+// Singleton access
++ (instancetype)sharedOverlay;
+
+// Display management
+- (void)showPreviewForRect:(NSValue *)rectValue;
+- (void)hide;
+
+@end

--- a/WindowManager/URSSnapPreviewOverlay.m
+++ b/WindowManager/URSSnapPreviewOverlay.m
@@ -1,0 +1,140 @@
+//
+//  URSSnapPreviewOverlay.m
+//  uroswm - Window Snap Preview Overlay
+//
+//  Shows a semi-transparent blue-tinted preview rectangle showing where
+//  a window will snap when the mouse button is released.
+//
+//  This overlay uses a similar pattern to URSWindowSwitcherOverlay:
+//  - Singleton for reuse
+//  - Semi-transparent with rounded corners (when compositor is available)
+//  - Above all windows during drag operations
+//
+
+#import "URSSnapPreviewOverlay.h"
+#import "URSCompositingManager.h"
+
+// Constants for the snap preview appearance
+static const CGFloat kCornerRadius = 8.0;
+static const CGFloat kBorderWidth = 3.0;
+
+#pragma mark - URSSnapPreviewOverlayView
+
+@interface URSSnapPreviewOverlayView : NSView
+@property (assign, nonatomic) BOOL useRoundedCorners;
+@end
+
+@implementation URSSnapPreviewOverlayView
+
+- (BOOL)isOpaque {
+    return NO;
+}
+
+- (void)drawRect:(NSRect)dirtyRect {
+    // Clear the background
+    [[NSColor clearColor] set];
+    NSRectFill(self.bounds);
+
+    // Draw just the outline so the window beneath is visible
+    NSBezierPath *previewPath;
+    NSRect insetBounds = NSInsetRect(self.bounds, kBorderWidth / 2, kBorderWidth / 2);
+
+    if (self.useRoundedCorners) {
+        previewPath = [NSBezierPath bezierPathWithRoundedRect:insetBounds
+                                                      xRadius:kCornerRadius
+                                                      yRadius:kCornerRadius];
+    } else {
+        previewPath = [NSBezierPath bezierPathWithRect:insetBounds];
+    }
+
+    // Blue border outline only (no fill)
+    [[NSColor colorWithCalibratedRed:0.2 green:0.5 blue:0.9 alpha:0.9] set];
+    [previewPath setLineWidth:kBorderWidth];
+    [previewPath stroke];
+}
+
+@end
+
+#pragma mark - URSSnapPreviewOverlay
+
+@implementation URSSnapPreviewOverlay
+
++ (instancetype)sharedOverlay {
+    static URSSnapPreviewOverlay *sharedOverlay = nil;
+    @synchronized(self) {
+        if (!sharedOverlay) {
+            sharedOverlay = [[URSSnapPreviewOverlay alloc] init];
+        }
+    }
+    return sharedOverlay;
+}
+
+- (instancetype)init {
+    // Start with a default size (will be updated when showing)
+    NSRect contentRect = NSMakeRect(0, 0, 400, 300);
+
+    self = [super initWithContentRect:contentRect
+                            styleMask:NSBorderlessWindowMask
+                              backing:NSBackingStoreBuffered
+                                defer:NO];
+
+    if (self) {
+        // Configure window appearance
+        // Use a high level to be above dragged windows
+        [self setLevel:NSFloatingWindowLevel];
+        [self setHasShadow:NO];
+        [self setOpaque:NO];
+        [self setBackgroundColor:[NSColor clearColor]];
+        [self setIgnoresMouseEvents:YES];  // Don't intercept drag events
+        [self setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+                                    NSWindowCollectionBehaviorStationary |
+                                    NSWindowCollectionBehaviorFullScreenAuxiliary];
+        [self setReleasedWhenClosed:NO];  // Keep window alive for reuse
+
+        // Create the content view
+        URSSnapPreviewOverlayView *contentView =
+            [[URSSnapPreviewOverlayView alloc] initWithFrame:contentRect];
+        [self setContentView:contentView];
+
+        NSLog(@"[SnapPreviewOverlay] Initialized");
+    }
+
+    return self;
+}
+
+- (void)showPreviewForRect:(NSValue *)rectValue {
+    if (!rectValue) {
+        [self hide];
+        return;
+    }
+
+    NSRect targetRect = [rectValue rectValue];
+
+    // Update window frame to match target snap area
+    [self setFrame:targetRect display:NO];
+
+    // Update content view frame
+    URSSnapPreviewOverlayView *view = (URSSnapPreviewOverlayView *)[self contentView];
+    [view setFrame:NSMakeRect(0, 0, targetRect.size.width, targetRect.size.height)];
+
+    // Check if compositing is active to determine whether to use rounded corners
+    URSCompositingManager *compositor = [URSCompositingManager sharedManager];
+    view.useRoundedCorners = [compositor compositingActive];
+
+    [view setNeedsDisplay:YES];
+
+    // Show the overlay
+    [self orderFront:nil];
+
+    NSLog(@"[SnapPreviewOverlay] Showing preview at (%.0f, %.0f) size %.0f x %.0f, rounded: %d",
+          targetRect.origin.x, targetRect.origin.y,
+          targetRect.size.width, targetRect.size.height,
+          view.useRoundedCorners);
+}
+
+- (void)hide {
+    [self orderOut:self];
+    NSLog(@"[SnapPreviewOverlay] Hidden");
+}
+
+@end

--- a/XCBKit/XCBConnection.h
+++ b/XCBKit/XCBConnection.h
@@ -24,7 +24,12 @@
 #define CLIENTLISTSIZE 1000
 #define WINDOWSMAPUPDATED @"windowsMapUpdated"
 
-// Snap zone types for window tiling
+// Edge snap detection constants
+#define SNAP_EDGE_THRESHOLD 5    // Pixels from screen edge to trigger snap detection
+#define SNAP_CORNER_THRESHOLD 50 // Pixels from corner to trigger quarter snap
+#define SNAP_LINGER_TIME 300     // Milliseconds to linger before snap activates
+
+// Snap zone types for drag-to-edge window snapping
 typedef NS_ENUM(NSInteger, SnapZone) {
     SnapZoneNone = 0,
     SnapZoneTop,         // Maximize window
@@ -70,6 +75,11 @@ typedef NS_ENUM(NSInteger, SnapZone) {
 // Expected focus tracking to prevent race conditions
 @property (nonatomic, assign) xcb_window_t expectedFocusWindow;
 @property (nonatomic, assign) xcb_timestamp_t expectedFocusTimestamp;
+
+// Edge snap detection state
+@property (nonatomic, assign) SnapZone pendingSnapZone;
+@property (nonatomic, assign) xcb_timestamp_t snapZoneEntryTime;
+@property (nonatomic, assign) BOOL snapPreviewShown;
 
 + (XCBConnection *) sharedConnectionAsWindowManager:(BOOL)asWindowManager;
 - (xcb_connection_t *) connection;
@@ -159,6 +169,8 @@ typedef NS_ENUM(NSInteger, SnapZone) {
 - (void)tileActiveWindowLeft;
 - (void)tileActiveWindowRight;
 - (void)tileActiveWindowToZone:(SnapZone)zone;
+- (void)showSnapPreviewForZone:(SnapZone)zone frame:(XCBFrame *)frame;
+- (void)hideSnapPreview;
 - (void)executeSnapForZone:(SnapZone)zone frame:(XCBFrame *)frame;
 
 @end


### PR DESCRIPTION
## Summary
- Add window tiling commands via `_GERSHWIN_*` X11 client messages
- Add drag-to-edge window snapping with preview overlay

![corners](https://github.com/user-attachments/assets/bc59f871-bd47-47cf-8eab-c1f8b160a9ec)

## Features
**Tiling Commands** (triggered from Menu):
- Center window on screen
- Maximize Vertical / Maximize Horizontal
- Tile left/right (half-screen)
- Tile to corners (quarter-screen)

**Snap-to-Edge** (drag window to screen edge):
- Drag to top edge: maximize
- Drag to left/right edge: half-screen tile
- Drag to corners: quarter-screen tile
- Visual preview overlay shows snap target

## Related
- Companion PR: gershwin-desktop/gershwin-components#32