### PR TITLE
Do not focus on window that does not support WM_TAKE_FOCUS

### DIFF
--- a/XCBKit/XCBWindow.m
+++ b/XCBKit/XCBWindow.m
@@ -1019,6 +1019,7 @@
         [connection sendEvent:(const char*) &event toClient:self propagate:NO];
     } else {
         NSLog(@"[FOCUS] Window %u does not support WM_TAKE_FOCUS", window);
+	return;
     }
 
     NSLog(@"[FOCUS] Updating _NET_ACTIVE_WINDOW for window %u", window);


### PR DESCRIPTION
This PR is related to https://github.com/gershwin-desktop/gershwin-eau-theme/issues/31

This change helps fix the case when the Shared Menu is used.  The Shared Menu should
not accept focus, but after selecting a menu item for an application like TextEdit, the focus shifts to 'Menu' before 'TextEdit' can process the item.  TextEdit reports that the menu selection is not valid.